### PR TITLE
feat: allow change of admin status after creation of user

### DIFF
--- a/src/blueprints/admin/user/__init__.py
+++ b/src/blueprints/admin/user/__init__.py
@@ -42,7 +42,14 @@ def edit(idx: int) -> View:
     if user == current_user:
         return redirect(url_for(".view"))
 
-    return render_template(join(TEMPLATES_DIR, "edit.html"), idx=idx)
+    return render_template(join(TEMPLATES_DIR, "edit.html"), idx=idx, admin=user.admin)
+
+@user.route("/change/<int:idx>", methods=["GET", "POST"])
+@admin_required
+@confirm_required
+def change(idx: int) -> View:
+    users.change_admin(idx)
+    return redirect(url_for(".view"))
 
 @user.route("/remove/<int:idx>", methods=["GET", "POST"])
 @admin_required

--- a/src/templates/admin/user/edit.html
+++ b/src/templates/admin/user/edit.html
@@ -9,6 +9,11 @@
 
   <input value="Change" type="submit" />
   <input
+    value="{% if admin %}Demote{% else %}Promote{% endif %}"
+    type="button"
+    onclick='window.location="{{ url_for('.change', idx=idx) }}"'
+  />
+  <input
     value="Remove"
     type="button"
     onclick='window.location="{{ url_for('.remove', idx=idx) }}"'

--- a/src/user.py
+++ b/src/user.py
@@ -132,6 +132,14 @@ class Users(SQLAlchemy):
         user.password = generate_password_hash(form["password_new"])
         self.session.commit()
 
+    def change_admin(self, idx: int) -> None:
+        user = self[idx]
+        if not user:
+            raise UserException("Invalid user!")
+
+        user.admin = not user.admin
+        self.session.commit()
+
 users = Users()
 
 if TYPE_CHECKING:


### PR DESCRIPTION
Added a promote/demote button in the user edit screen for admins. This button effectively toggles the admin status of a given user.

Resolves #7.