### PR TITLE
fix: error reporting passwords do not match even when they do

### DIFF
--- a/src/user.py
+++ b/src/user.py
@@ -113,7 +113,7 @@ class Users(SQLAlchemy):
         if not user:
             raise UserException("Invalid user!")
 
-        if form["password_new"] is not form["password_check"]:
+        if form["password_new"] != form["password_check"]:
             raise UserException("Passwords do not match!")
         if not check_password_hash(user.password, form["password_old"]):
             raise UserException("Invalid password!")


### PR DESCRIPTION
Due to the use of an `is not` comparison instead of `!=`, users were told their new passwords did not match even when they did.

Resolves #4.