### PR TITLE
fix: allows longer usernames without causing topnav to use multiple lines

### DIFF
--- a/src/static/topnav.css
+++ b/src/static/topnav.css
@@ -33,9 +33,8 @@
   font-size: 16px;
 
   box-sizing: border-box;
-  width: 100px;
   height: 100%;
-  padding: 14px 0;
+  padding: 14px 8px;
 
   color: var(--text_primary_inactive);
   border: none;
@@ -50,8 +49,7 @@
 
   display: none;
 
-  width: 100px;
-
+  min-width: 100%;
   background-color: var(--primary);
   box-shadow: 0px 8px 16px 0px var(--shadow);
 }


### PR DESCRIPTION
Due to a container having fixed `width`, longer usernames were causing the `topnav` to use multiple lines. This fix implements dynamic width containers to stop the username having to wrap over multiple lines.

Resolves #5. 