### PR TITLE
feat: added 'online' as a location

### DIFF
--- a/src/options/locations.json
+++ b/src/options/locations.json
@@ -1,1 +1,1 @@
-["Stag Hill", "Manor Park", "Off-Campus", "Kate Granger"]
+["Online", "Stag Hill", "Manor Park", "Off-Campus", "Kate Granger"]


### PR DESCRIPTION
The easiest way to record online sessions alongside in-person sessions is to include 'online' as a location. Splitting the sessions into online and in-person can then be done by checking the location.

Resolves #1. 